### PR TITLE
Allow collection of email and other profile details from LinkedIn during identity retrieval

### DIFF
--- a/linkedin_server.js
+++ b/linkedin_server.js
@@ -1,25 +1,40 @@
 var urlUtil = Npm.require('url');
 
+// Use this for advanced configuration of LinkedIn integration, such as customizing what the API returns based on your application needs & requested permissions. Possible options:
+// 		
+// 		fields: an Array of LinkedIn fields, such as ['id','firstName','lastName','emailAddress','headline','memberUrlResources','pictureUrl','location','publicProfileUrl','siteStandardProfileRequest']
+LinkedIn.config = {
+	fields: []	
+};
+
+// These fields are requested by default and added to the user's profile
+var whiteListed = ['firstName', 'headline', 'lastName'];
+
+// You can use LinkedIn.config to add extra fields
+var getFields = function(){
+	return _.uniq(whiteListed.concat(LinkedIn.config.fields || []));
+}
+
 OAuth.registerService('linkedin', 2, null, function (query) {
 
     var response = getTokens(query);
     var accessToken = response.accessToken;
     var identity = getIdentity(accessToken);
 
-    var profileUrl = identity.siteStandardProfileRequest.url;
-    var urlParts = urlUtil.parse(profileUrl, true);
+		if(identity.siteStandardProfileRequest){
+			var profileUrl = identity.siteStandardProfileRequest.url;
+			var urlParts = urlUtil.parse(profileUrl, true);
+		}
 
     var serviceData = {
-        id: urlParts.query.id || Random.id(),
+        id: identity.id || urlParts.query.id || Random.id(),
         accessToken: OAuth.sealSecret(accessToken),
         expiresAt: (+new Date) + (1000 * response.expiresIn)
     };
 
-    var whiteListed = ['firstName', 'headline', 'lastName'];
-
-    // include all fields from linkedin
+    // include selected fields from linkedin
     // https://developer.linkedin.com/documents/authentication
-    var fields = _.pick(identity, whiteListed);
+    var fields = _.pick(identity, getFields());
 
     fields.name = identity.firstName + ' ' + identity.lastName;
 
@@ -87,7 +102,7 @@ var getTokens = function (query) {
 
 var getIdentity = function (accessToken) {
     try {
-        return HTTP.get('https://www.linkedin.com/v1/people/~', {
+        return HTTP.get('https://www.linkedin.com/v1/people/~:('+getFields().join(',')+')', {
             params: { oauth2_access_token: accessToken, format: 'json'}
         }).data;
     } catch (err) {

--- a/linkedin_server.js
+++ b/linkedin_server.js
@@ -8,7 +8,7 @@ LinkedIn.config = {
 };
 
 // These fields are requested by default and added to the user's profile
-var whiteListed = ['firstName', 'headline', 'lastName'];
+var whiteListed = ['firstName', 'headline', 'lastName', 'siteStandardProfileRequest'];
 
 // You can use LinkedIn.config to add extra fields
 var getFields = function(){

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'jonperl:linkedin',
   summary: 'LinkedIn accounts OAuth flow',
-  version: '1.1.0',
+  version: '1.1.1',
   git: 'https://github.com/jperl/meteor-linkedin'
 });
 


### PR DESCRIPTION
Hey Jon,

Thanks for doing the hard part! I noticed that I wasn't getting back all the dataz I can haz, so I modified the library just a bit so that you can request whatever you want during the identity retrieval process. If the following is given (server side):

```
LinkedIn.config.fields = ['emailAddress']
```

...then the response will include the user's email, as well as the defaults you have.

I modified and tested the package locally.
